### PR TITLE
fix(sprint-1): critical fixes — plugin manifest, gitignore, error log, README

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,14 @@
   },
   "license": "MIT",
   "category": "development",
-  "keywords": ["yolo", "autonomous", "team-build", "background", "multi-agent"]
+  "keywords": ["yolo", "autonomous", "team-build", "background", "multi-agent"],
+  "commands": [
+    "commands/yolo.md",
+    "commands/rbg.md",
+    "commands/team-build.md",
+    "commands/yolo-log.md"
+  ],
+  "skills": [
+    "skills/autonomous-ops/SKILL.md"
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Runtime directories (never commit)
+.yolo/
+.team-build/
+.jira-state/
+
+# macOS
+.DS_Store
+
+# Editor
+.vscode/
+.idea/
+
+# Node (if any tooling is added)
+node_modules/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ Claude Code plugin bundling autonomous execution modes: full YOLO mode, backgrou
 ## Install
 
 ```bash
-claude plugin install autonomous-ops@musabkara-claude-marketplace
+# From the Claude marketplace (once published):
+claude plugin install autonomous-ops
+
+# Or install directly from source:
+git clone https://github.com/SkyWalker2506/ccplugin-autonomous-ops
+claude plugin install ./ccplugin-autonomous-ops
 ```
 
 ## Commands

--- a/analysis/MASTER_ANALYSIS.md
+++ b/analysis/MASTER_ANALYSIS.md
@@ -1,0 +1,123 @@
+# Master Analysis — ccplugin-autonomous-ops
+
+**Date:** 2026-04-22  
+**Analyst:** Jarvis (Sonnet 4.6)  
+**Repo:** SkyWalker2506/ccplugin-autonomous-ops
+
+---
+
+## 1. Project Overview
+
+`ccplugin-autonomous-ops` is a Claude Code plugin that bundles four autonomous execution modes:
+
+| Command | Purpose |
+|---------|---------|
+| `/yolo <task>` | Full autonomous, zero-question task runner with per-step commits |
+| `/rbg <task>` | Background agent delegation via `run_in_background: true` |
+| `/team-build [setup/run/status]` | Multi-agent development loop: Opus specs, Sonnet/Haiku codes |
+| `/yolo-log [--all]` | Read-only report of last /yolo run |
+
+**Plugin metadata:** `name: autonomous-ops`, `version: 1.0.0`, `category: development`
+
+---
+
+## 2. File Structure
+
+```
+ccplugin-autonomous-ops/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin manifest
+├── commands/
+│   ├── yolo.md              # /yolo command spec (169 lines)
+│   ├── rbg.md               # /rbg command spec (50 lines)
+│   ├── team-build.md        # /team-build command spec (260 lines)
+│   └── yolo-log.md          # /yolo-log command spec (71 lines)
+├── skills/
+│   └── autonomous-ops/
+│       └── SKILL.md         # Unified auto-trigger skill
+├── CLAUDE.md                # Redirector to claude-config
+├── README.md                # Public-facing plugin docs
+└── LICENSE                  # MIT
+```
+
+---
+
+## 3. Strengths
+
+1. **Clear separation of concerns** — each command in its own `.md`, unified skill for auto-trigger
+2. **Safety guardrails built-in** — no `rm -rf`, no force push, no secrets in code, even in YOLO mode
+3. **Obstacle bypass catalog** — systematic fallback table for DB, auth, API keys, Jira, Docker, CI/CD
+4. **Structured logging** — `.yolo/log.json` + `.yolo/skipped.json` with typed action fields
+5. **Context-resilient team-build** — reports/specs on disk survive context cleanup between turns
+6. **Model tiering** — Haiku for simple tasks, Sonnet for heavy, Opus only for spec/review
+
+---
+
+## 4. Gaps & Issues
+
+### 4.1 Critical Gaps
+
+| # | Gap | Impact |
+|---|-----|--------|
+| G1 | **No tests** — zero test files or test configuration | Commands can regress silently |
+| G2 | **`team-build.sh` referenced but missing** — `~/Projects/claude-config/projects/scripts/team-build.sh` does not exist in this repo | `/team-build run` would fail |
+| G3 | **No `commands` or `skills` declared in `plugin.json`** — the manifest has no paths to commands/skills | Plugin installer cannot discover commands |
+| G4 | **`/rbg` `disable-model-invocation: true` with no fallback handler** — unclear how the skill actually dispatches without model invocation | Could silently no-op |
+
+### 4.2 Quality Gaps
+
+| # | Gap | Impact |
+|---|-----|--------|
+| G5 | **YOLO log format has no `error` action type** — only `create/modify/configure/scaffold/install/skip/complete` | No way to record partial failures |
+| G6 | **`/yolo` agent prompt template has hardcoded `model="sonnet"`** — not configurable per-project | Inflexible for Haiku/Opus overrides |
+| G7 | **Team-build config has no `version` field** — schema drift risk across iterations | Config parsing could break silently |
+| G8 | **`/yolo-log` has no JSON schema validation** — corrupted log file would show nothing | Silent failures |
+| G9 | **README install command uses non-existent marketplace slug** `autonomous-ops@musabkara-claude-marketplace` | User install would fail |
+| G10 | **No `.gitignore` entries for `.team-build/` in plugin itself** — team-build docs say to exclude it but plugin doesn't enforce | Secrets/reports leak into git |
+
+### 4.3 Enhancement Opportunities
+
+| # | Opportunity | Value |
+|---|-------------|-------|
+| E1 | **`/yolo --dry-run`** — show what would be done without executing | Safer onboarding |
+| E2 | **`/yolo --model <name>`** — override agent model at invocation time | Flexibility |
+| E3 | **`/team-build status`** — fully spec'd but not implemented | Visibility |
+| E4 | **`/yolo` watchdog self-check at 25 calls** (currently max 50) | Faster recovery |
+| E5 | **Structured `plugin.json`** with `commands` and `skills` arrays | Proper plugin discovery |
+
+---
+
+## 5. Risk Assessment
+
+| Risk | Severity | Likelihood |
+|------|----------|-----------|
+| `team-build.sh` missing → `/team-build run` silently fails | High | Certain |
+| `plugin.json` missing `commands`/`skills` → install broken | High | Certain |
+| No error log action → YOLO failures invisible in log | Medium | Likely |
+| README install slug wrong → user can't install | Medium | Certain |
+| No tests → regressions undetected | Medium | Certain |
+
+---
+
+## 6. Prioritized Sprint Plan Preview
+
+**Sprint 1 (Critical Fixes):** Fix plugin.json manifest, fix README install slug, add `error` log action, add `.gitignore` for `.team-build/`
+
+**Sprint 2 (Team-Build Completion):** Implement team-build.sh shell script, add `version` field to team-build config schema, implement `/team-build status` command, add JSON schema validation to yolo-log
+
+**Sprint 3 (Quality & Tests):** Add test suite scaffolding, implement `--dry-run` for `/yolo`, implement `--model` override for `/yolo`, add config-driven model selection
+
+---
+
+## 7. Metrics
+
+| Metric | Value |
+|--------|-------|
+| Total files | 8 (excluding git/DS_Store) |
+| Command specs | 4 |
+| Skill files | 1 |
+| Lines of command specs | ~550 |
+| Test coverage | 0% |
+| Critical bugs | 4 (G1-G4) |
+| Quality gaps | 6 (G5-G10) |
+| Enhancement opps | 5 (E1-E5) |

--- a/analysis/SPRINT_PLAN.md
+++ b/analysis/SPRINT_PLAN.md
@@ -1,0 +1,47 @@
+# Sprint Plan — ccplugin-autonomous-ops
+
+**Generated:** 2026-04-22  
+**Forge runs:** 3  
+**Total sprints:** 3 (one per run)
+
+---
+
+## Sprint 1 — Critical Fixes (Run 1)
+
+**Goal:** Fix all blockers that prevent the plugin from working after install.
+
+| # | Task | Files | Effort |
+|---|------|-------|--------|
+| S1-T1 | Fix `plugin.json` — add `commands` and `skills` arrays with correct paths | `.claude-plugin/plugin.json` | S |
+| S1-T2 | Fix README install command slug to use correct marketplace reference | `README.md` | XS |
+| S1-T3 | Add `error` action type to YOLO log format in `/yolo` command | `commands/yolo.md` | XS |
+| S1-T4 | Add `.gitignore` to repo with `.team-build/` and `.yolo/` excluded | `.gitignore` | XS |
+| S1-T5 | Add `version` to team-build config schema + document it | `commands/team-build.md` | XS |
+
+---
+
+## Sprint 2 — Team-Build Completion (Run 2)
+
+**Goal:** Make `/team-build run` actually work end-to-end.
+
+| # | Task | Files | Effort |
+|---|------|-------|--------|
+| S2-T1 | Create `team-build.sh` shell script for autonomous loop | `scripts/team-build.sh` | M |
+| S2-T2 | Implement `/team-build status` subcommand spec | `commands/team-build.md` | S |
+| S2-T3 | Add JSON schema validation guard to `/yolo-log` | `commands/yolo-log.md` | XS |
+| S2-T4 | Add `rbg` dispatch clarification for `disable-model-invocation` | `commands/rbg.md` | XS |
+| S2-T5 | Add `SKILL.md` trigger keywords for Turkish variations (`takımla yap` etc.) | `skills/autonomous-ops/SKILL.md` | XS |
+
+---
+
+## Sprint 3 — Quality & Enhancement (Run 3)
+
+**Goal:** Test scaffolding, UX improvements, and `--dry-run`/`--model` flags.
+
+| # | Task | Files | Effort |
+|---|------|-------|--------|
+| S3-T1 | Add `--dry-run` flag spec to `/yolo` command | `commands/yolo.md` | S |
+| S3-T2 | Add `--model <name>` override flag to `/yolo` command | `commands/yolo.md` | S |
+| S3-T3 | Create `tests/` directory with basic smoke test scripts | `tests/smoke.sh`, `tests/README.md` | M |
+| S3-T4 | Add watchdog self-check at 25-call mark (not just max-50) | `commands/yolo.md` | XS |
+| S3-T5 | Update plugin.json version to 1.1.0 reflecting all changes | `.claude-plugin/plugin.json` | XS |

--- a/commands/team-build.md
+++ b/commands/team-build.md
@@ -68,6 +68,7 @@ Create `.team-build/config.json` from answers:
 
 ```json
 {
+  "version": "1.0",
   "project": "Project Name",
   "description": "Short description",
   "type": "website",
@@ -88,6 +89,9 @@ Create `.team-build/config.json` from answers:
   "webResearch": true,
   "createdAt": "2026-04-01T12:00:00Z"
 }
+```
+
+> **Note:** If `version` is missing from an existing config file, treat it as `"1.0"` for backward compatibility.
 ```
 
 Agent model assignment:

--- a/commands/yolo.md
+++ b/commands/yolo.md
@@ -67,7 +67,21 @@ JSON array, each entry:
 }
 ```
 
-- `action`: `create` | `modify` | `configure` | `scaffold` | `install` | `skip`
+For errors, use `action: "error"` with an additional `error` field:
+
+```json
+{
+  "step": 3,
+  "action": "error",
+  "what": "Failed to install dependencies",
+  "files": [],
+  "commit": null,
+  "error": "npm ERR! code ENOTFOUND",
+  "ts": "2026-04-02T14:32:00Z"
+}
+```
+
+- `action`: `create` | `modify` | `configure` | `scaffold` | `install` | `skip` | `error` | `watchdog-check` | `complete`
 - `what`: what was done (1 sentence, English)
 - `files`: changed/created files
 - `commit`: commit hash (`null` if none)


### PR DESCRIPTION
## Summary

- **plugin.json**: Added `commands` and `skills` arrays so the Claude Code installer can discover all 4 commands and the `autonomous-ops` skill — without this the plugin was non-functional after install
- **.gitignore**: Added repo-level gitignore excluding `.yolo/`, `.team-build/`, `.jira-state/`, `.DS_Store`
- **README**: Fixed broken install command slug — replaced non-existent `autonomous-ops@musabkara-claude-marketplace` with correct instructions
- **yolo.md**: Added `error` and `watchdog-check` action types to the log format, with a dedicated `error` field for failure messages
- **team-build.md**: Added `version: "1.0"` to config schema with backward-compat note for existing configs

Closes #1 #2 #3 #4 #5

## Test plan
- [ ] `claude plugin install ./ccplugin-autonomous-ops` succeeds and all 4 commands are discoverable
- [ ] `.gitignore` prevents `.yolo/` and `.team-build/` from being staged
- [ ] README install instructions are accurate
- [ ] `/yolo` agent logs errors with `action: "error"` and `error` field

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Forge Run 1