### PR TITLE
feat(sprint-3): --dry-run, --model flags, watchdog-check, smoke tests, v1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autonomous-ops",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Claude Code plugin bundling autonomous execution modes: full YOLO mode, background agent delegation, and multi-agent team build loops.",
   "author": {
     "name": "Musab Kara",

--- a/commands/yolo.md
+++ b/commands/yolo.md
@@ -8,6 +8,18 @@ argument-hint: "<task description>"
 
 Execute the given task with **zero questions asked**, going as far as possible. Obstacles are bypassed, every milestone gets a commit, and results are reported.
 
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | off | Analyze and plan only — no file writes, no commits |
+| `--model <name>` | `sonnet` | Override agent model: `haiku` \| `sonnet` \| `opus` |
+
+Examples:
+- `/yolo --dry-run add authentication` — preview the plan, no execution
+- `/yolo --model haiku add a CHANGELOG.md` — use Haiku (faster, cheaper) for simple tasks
+- `/yolo --model opus redesign the entire auth system` — use Opus for complex, high-stakes work
+
 ## Core Principles
 
 1. **NEVER ask questions** — no user prompts, no confirmation waits
@@ -43,6 +55,33 @@ Add `.yolo/` to `.gitignore` (create if missing, append if exists).
 ### 2. Analysis (max 5 tool calls)
 
 Quick scan of the project: language, framework, structure. No long exploration.
+
+### 2b. Flag: `--dry-run`
+
+If `--dry-run` is in arguments:
+
+1. Run analysis (step 2) normally
+2. Output a plan table:
+   ```
+   ## /yolo Dry Run — <task>
+
+   | Step | Action | Files | Obstacle Risk |
+   |------|--------|-------|---------------|
+   | 1 | Scaffold Next.js project | package.json, app/ | Low |
+   | 2 | Add auth middleware | middleware.ts | Medium — will use fake auth |
+   | 3 | Create dashboard page | app/dashboard/page.tsx | Low |
+
+   Dry run complete. Run `/yolo <task>` to execute.
+   ```
+3. **Stop here** — no files written, no commits, no log entries (or log with `"action": "planned"`)
+
+### 2c. Flag: `--model <name>`
+
+Parse `--model` from arguments before execution:
+- Valid values: `haiku`, `sonnet`, `opus`
+- Default: `sonnet`
+- Invalid value: show error and exit — `Invalid model "<value>". Valid options: haiku, sonnet, opus`
+- Use the resolved model in the Agent prompt template (replacing hardcoded `model="sonnet"`)
 
 ### 3. Execution
 
@@ -156,16 +195,19 @@ Agent(
   8. On completion: add "complete" entry to .yolo/log.json.
 
   LOG ENTRY FORMAT:
-  {"step": N, "action": "create|modify|configure|scaffold|install|skip", "what": "...", "files": [...], "commit": "hash|null", "ts": "ISO"}
+  {"step": N, "action": "create|modify|configure|scaffold|install|skip|error|watchdog-check|complete", "what": "...", "files": [...], "commit": "hash|null", "ts": "ISO"}
+  For errors add: "error": "<message>"
 
   SKIP ENTRY FORMAT:
   {"what": "...", "reason": "...", "workaround": "..."}
 
   OBSTACLE BYPASS: DB->mock, Auth->fake, API key->fallback, Jira->skip, Paid->skip, Docker->skip, CI->simple script.
 
-  WATCHDOG: This task is long. Max 50 tool calls. Self-check every 5 calls.
+  WATCHDOG:
+  - Self-check at call 25: Review progress, log {"action": "watchdog-check", "what": "25-call check", "calls_used": 25, "decision": "continue|wrap-up|escalate", "ts": "ISO"}. If more than 80% done, continue. If stuck or looping, wrap up and log summary.
+  - Hard limit at call 50: Force completion — add "complete" entry and stop.
   """,
-  model="sonnet",
+  model="$MODEL",  # Replace with resolved model: haiku | sonnet | opus (default: sonnet)
   run_in_background=True,
   description="yolo: <task summary>"
 )

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# smoke.sh — Plugin structure validation for ccplugin-autonomous-ops
+# Usage: bash tests/smoke.sh
+# Exit: 0 if all checks pass, 1 if any fail
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"  # "ok" or "fail: <reason>"
+  if [ "$result" = "ok" ]; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        $result"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+file_exists() {
+  local path="$REPO_ROOT/$1"
+  if [ -f "$path" ]; then
+    echo "ok"
+  else
+    echo "fail: file not found: $1"
+  fi
+}
+
+file_executable() {
+  local path="$REPO_ROOT/$1"
+  if [ -x "$path" ]; then
+    echo "ok"
+  else
+    echo "fail: not executable: $1"
+  fi
+}
+
+json_valid() {
+  local path="$REPO_ROOT/$1"
+  if [ ! -f "$path" ]; then
+    echo "fail: file not found: $1"
+    return
+  fi
+  if command -v jq &>/dev/null; then
+    if jq . "$path" >/dev/null 2>&1; then
+      echo "ok"
+    else
+      echo "fail: invalid JSON: $1"
+    fi
+  else
+    echo "ok"  # skip jq check if not available
+  fi
+}
+
+json_has_key() {
+  local path="$REPO_ROOT/$1"
+  local key="$2"
+  if [ ! -f "$path" ]; then
+    echo "fail: file not found: $1"
+    return
+  fi
+  if command -v jq &>/dev/null; then
+    local val
+    val=$(jq -r "$key // empty" "$path" 2>/dev/null)
+    if [ -n "$val" ]; then
+      echo "ok"
+    else
+      echo "fail: key '$key' missing or empty in $1"
+    fi
+  else
+    echo "ok"  # skip if jq not available
+  fi
+}
+
+shell_syntax_ok() {
+  local path="$REPO_ROOT/$1"
+  if [ ! -f "$path" ]; then
+    echo "fail: file not found: $1"
+    return
+  fi
+  if bash -n "$path" 2>/dev/null; then
+    echo "ok"
+  else
+    echo "fail: syntax error in $1"
+  fi
+}
+
+frontmatter_has() {
+  local path="$REPO_ROOT/$1"
+  local field="$2"
+  if [ ! -f "$path" ]; then
+    echo "fail: file not found: $1"
+    return
+  fi
+  if grep -q "^$field:" "$path" 2>/dev/null; then
+    echo "ok"
+  else
+    echo "fail: frontmatter field '$field' missing in $1"
+  fi
+}
+
+echo "================================================"
+echo " ccplugin-autonomous-ops — Smoke Tests"
+echo "================================================"
+echo ""
+
+echo "## Plugin Manifest"
+check "plugin.json exists"                        "$(file_exists '.claude-plugin/plugin.json')"
+check "plugin.json is valid JSON"                 "$(json_valid '.claude-plugin/plugin.json')"
+check "plugin.json has name"                      "$(json_has_key '.claude-plugin/plugin.json' '.name')"
+check "plugin.json has version"                   "$(json_has_key '.claude-plugin/plugin.json' '.version')"
+check "plugin.json has commands array"            "$(json_has_key '.claude-plugin/plugin.json' '.commands[0]')"
+check "plugin.json has skills array"              "$(json_has_key '.claude-plugin/plugin.json' '.skills[0]')"
+echo ""
+
+echo "## Command Files"
+check "commands/yolo.md exists"                   "$(file_exists 'commands/yolo.md')"
+check "commands/rbg.md exists"                    "$(file_exists 'commands/rbg.md')"
+check "commands/team-build.md exists"             "$(file_exists 'commands/team-build.md')"
+check "commands/yolo-log.md exists"               "$(file_exists 'commands/yolo-log.md')"
+check "yolo.md has name frontmatter"              "$(frontmatter_has 'commands/yolo.md' 'name')"
+check "rbg.md has name frontmatter"               "$(frontmatter_has 'commands/rbg.md' 'name')"
+check "team-build.md has name frontmatter"        "$(frontmatter_has 'commands/team-build.md' 'name')"
+check "yolo-log.md has name frontmatter"          "$(frontmatter_has 'commands/yolo-log.md' 'name')"
+echo ""
+
+echo "## Skill Files"
+check "skills/autonomous-ops/SKILL.md exists"     "$(file_exists 'skills/autonomous-ops/SKILL.md')"
+check "SKILL.md has name frontmatter"             "$(frontmatter_has 'skills/autonomous-ops/SKILL.md' 'name')"
+check "SKILL.md has description frontmatter"      "$(frontmatter_has 'skills/autonomous-ops/SKILL.md' 'description')"
+echo ""
+
+echo "## Scripts"
+check "scripts/team-build.sh exists"              "$(file_exists 'scripts/team-build.sh')"
+check "scripts/team-build.sh is executable"       "$(file_executable 'scripts/team-build.sh')"
+check "scripts/team-build.sh syntax OK"           "$(shell_syntax_ok 'scripts/team-build.sh')"
+echo ""
+
+echo "## Repo Hygiene"
+check ".gitignore exists"                         "$(file_exists '.gitignore')"
+check "README.md exists"                          "$(file_exists 'README.md')"
+check "LICENSE exists"                            "$(file_exists 'LICENSE')"
+echo ""
+
+echo "## Analysis Files"
+check "analysis/MASTER_ANALYSIS.md exists"        "$(file_exists 'analysis/MASTER_ANALYSIS.md')"
+check "analysis/SPRINT_PLAN.md exists"            "$(file_exists 'analysis/SPRINT_PLAN.md')"
+echo ""
+
+echo "================================================"
+echo " Results: $PASS passed, $FAIL failed"
+echo "================================================"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/validate-log-schema.sh
+++ b/tests/validate-log-schema.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# validate-log-schema.sh — Validates .yolo/log.json against expected schema
+# Usage: bash tests/validate-log-schema.sh [path/to/log.json]
+# Exit: 0 if valid, 1 if invalid
+
+set -euo pipefail
+
+LOG_FILE="${1:-.yolo/log.json}"
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [ "$result" = "ok" ]; then
+    echo "  PASS  $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $desc"
+    echo "        $result"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+VALID_ACTIONS="create modify configure scaffold install skip error watchdog-check complete planned"
+
+echo "================================================"
+echo " /yolo Log Schema Validator"
+echo " File: $LOG_FILE"
+echo "================================================"
+echo ""
+
+# Check file existence
+if [ ! -f "$LOG_FILE" ]; then
+  echo "  FAIL  Log file does not exist: $LOG_FILE"
+  echo ""
+  echo "  Hint: Run /yolo first to generate the log."
+  exit 1
+fi
+echo "  PASS  File exists: $LOG_FILE"
+
+# Check not empty
+if [ ! -s "$LOG_FILE" ]; then
+  echo "  FAIL  File is empty"
+  exit 1
+fi
+echo "  PASS  File is non-empty"
+
+# Check valid JSON
+if ! command -v jq &>/dev/null; then
+  echo "  SKIP  jq not found — install with: brew install jq"
+  exit 0
+fi
+
+if ! jq . "$LOG_FILE" >/dev/null 2>&1; then
+  echo "  FAIL  Invalid JSON in $LOG_FILE"
+  echo "        First 200 chars: $(head -c 200 "$LOG_FILE")"
+  exit 1
+fi
+echo "  PASS  Valid JSON"
+
+# Check it's an array
+TYPE=$(jq -r 'type' "$LOG_FILE")
+if [ "$TYPE" != "array" ]; then
+  echo "  FAIL  Expected JSON array, got: $TYPE"
+  exit 1
+fi
+echo "  PASS  Is a JSON array"
+
+# Check if array is empty
+COUNT=$(jq 'length' "$LOG_FILE")
+if [ "$COUNT" -eq 0 ]; then
+  echo "  WARN  Empty array — no steps recorded yet"
+  echo ""
+  echo " Results: $PASS passed, $FAIL failed, 1 warning"
+  exit 0
+fi
+echo "  PASS  Contains $COUNT entries"
+echo ""
+
+echo "## Entry Validation"
+
+# Validate each entry
+ENTRY_FAIL=0
+jq -c '.[]' "$LOG_FILE" | while IFS= read -r entry; do
+  idx=$(echo "$entry" | jq -r '.step // "?"')
+
+  # Required fields
+  for field in step action what ts; do
+    val=$(echo "$entry" | jq -r ".$field // empty")
+    if [ -z "$val" ]; then
+      echo "  FAIL  Entry step=$idx: missing required field '$field'"
+      ENTRY_FAIL=$((ENTRY_FAIL + 1))
+    fi
+  done
+
+  # Validate action type
+  action=$(echo "$entry" | jq -r '.action // empty')
+  if [ -n "$action" ]; then
+    valid=false
+    for a in $VALID_ACTIONS; do
+      [ "$action" = "$a" ] && valid=true && break
+    done
+    if [ "$valid" = "false" ]; then
+      echo "  FAIL  Entry step=$idx: invalid action '$action'"
+      echo "        Valid: $VALID_ACTIONS"
+      ENTRY_FAIL=$((ENTRY_FAIL + 1))
+    fi
+  fi
+
+  # If action=error, must have error field
+  if [ "$action" = "error" ]; then
+    err=$(echo "$entry" | jq -r '.error // empty')
+    if [ -z "$err" ]; then
+      echo "  WARN  Entry step=$idx: action=error but no 'error' field"
+    fi
+  fi
+
+  # files must be array
+  files_type=$(echo "$entry" | jq -r '.files | type // empty' 2>/dev/null)
+  if [ -n "$files_type" ] && [ "$files_type" != "array" ]; then
+    echo "  FAIL  Entry step=$idx: 'files' must be array, got $files_type"
+    ENTRY_FAIL=$((ENTRY_FAIL + 1))
+  fi
+
+  echo "  PASS  Entry step=$idx (action=$action)"
+done
+
+echo ""
+echo "================================================"
+echo " Schema validation complete"
+echo "================================================"
+
+if [ "$ENTRY_FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **--dry-run flag for /yolo**: Analysis phase runs normally, outputs a plan table with steps + obstacle risk estimates, stops before any execution — no file writes, no commits
- **--model flag for /yolo**: Override the hardcoded `sonnet` model per invocation (`haiku|sonnet|opus`), with validation and error message for invalid values
- **Watchdog self-check at call 25**: Agent logs a `watchdog-check` entry with decision (`continue|wrap-up|escalate`), reducing waste from stuck agents burning 50 calls before recovery
- **tests/smoke.sh**: 25 structural checks covering plugin.json manifest, all 4 command files, skill file, scripts, and repo hygiene — all pass on current state
- **tests/validate-log-schema.sh**: Validates `.yolo/log.json` for JSON validity, array type, required fields, valid action types, and error-action field presence
- **plugin.json v1.1.0**: Version bump reflecting all Sprint 1-3 improvements

Closes #11 #12 #13 #14 #15

## Test plan
- [ ] `bash tests/smoke.sh` → 25/25 pass
- [ ] `bash tests/validate-log-schema.sh <valid-log>` → exits 0
- [ ] `bash tests/validate-log-schema.sh <corrupted-log>` → exits 1 with clear message
- [ ] `/yolo --dry-run add a README section` → shows plan, no files changed
- [ ] `/yolo --model haiku <simple task>` → uses haiku agent
- [ ] `/yolo --model invalid` → shows error with valid options

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Forge Run 3